### PR TITLE
v1.4.0: performance, bug fixes, version-manager-agnostic checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.4.0] - 2026-03-26
 
 ### Added
-- Git status indicators for unmerged, diverged, and stashed states
+- Git status indicators for unmerged and diverged states
 - Version-manager-agnostic node version display (`node_prompt_info`)
 - Version-manager-agnostic python version display (`python_prompt_info`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+## [1.4.0] - 2026-03-26
+
+### Added
+- Git status indicators for unmerged, diverged, and stashed states
+- Version-manager-agnostic node version display (`node_prompt_info`)
+- Version-manager-agnostic python version display (`python_prompt_info`)
+
+### Changed
+- Git status uses single `git status` call instead of two (performance)
+- Git status uses native zsh pattern matching instead of grep subprocesses (performance)
+- SSH check computed once at load time instead of every prompt (performance)
+
+### Deprecated
+- `nvm_prompt_info` (use `node_prompt_info`; old function still works)
+- `pyenv_prompt_info` (use `python_prompt_info`; old function still works)
+
+### Fixed
+- Unquoted variable expansions in echo statements
+
+### Removed
+- Unused `get_space()` function
+
+## [1.3.0] - 2021-07-12
+- Autoload zsh colors module
+
+## [1.2.0] - 2021-02-08
+- Add pyenv version display
+- Switch to unicode brackets and smaller git icons
+- Add version badge
+
+## [1.1.1] - 2017-10-04
+- Switch nvm to node logo
+- Remove makefile
+- Readme improvements
+
+## [1.0.4] - 2017-02-12
+- Revert to white colors for Alacritty compatibility
+
+## [1.0.3] - 2017-02-12
+- Fix SSH spacing
+- Change colors for Alacritty support
+
+## [1.0.1] - 2017-02-09
+- Initial stable release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.4.0] - 2026-03-26
 
 ### Added
-- Git status indicators for unmerged and diverged states
+- Git status indicator for unmerged state
 - Version-manager-agnostic node version display (`node_prompt_info`)
 - Version-manager-agnostic python version display (`python_prompt_info`)
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2021 Jade Michael Thornton
+Copyright (c) 2017-2026 Jade Michael Thornton
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A simple, informative theme for Zsh.
 
 Features:
 
-- Current versions for `nvm` and `pyenv`
+- Current Node.js and Python versions
 - Git branch and status
 - Timestamp
 - SSH indication
@@ -27,7 +27,7 @@ zpico add thornjad/vero source:gitlab
 
 ## Copying
 
-Copyright (c) 2017-2021 Jade Michael Thornton
+Copyright (c) 2017-2026 Jade Michael Thornton
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/vero.zsh-theme
+++ b/vero.zsh-theme
@@ -36,6 +36,9 @@ ZSH_THEME_GIT_PROMPT_BEHIND="%{$fg[magenta]%}▾%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_STAGED="%{$fg_bold[green]%}•%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_UNSTAGED="%{$fg_bold[yellow]%}•%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg_bold[red]%}•%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_UNMERGED="%{$fg_bold[red]%}✕%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_DIVERGED="%{$fg[magenta]%}↕%{$reset_color%}"
+ZSH_THEME_GIT_PROMPT_STASHED="%{$fg_bold[blue]%}⚑%{$reset_color%}"
 
 vero_git_branch () {
   ref=$(command git symbolic-ref HEAD 2> /dev/null) || \

--- a/vero.zsh-theme
+++ b/vero.zsh-theme
@@ -48,28 +48,28 @@ vero_git_branch () {
 
 vero_git_status() {
   _STATUS=""
+  _INDEX=$(command git status --porcelain -b 2> /dev/null)
 
   # check status of files
-  _INDEX=$(command git status --porcelain 2> /dev/null)
-  if [[ -n "$_INDEX" ]]; then
-    if $(echo "$_INDEX" | command grep -q '^[AMRD]. '); then
-      _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_STAGED"
-    fi
-    if $(echo "$_INDEX" | command grep -q '^.[MTD] '); then
-      _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_UNSTAGED"
-    fi
-    if $(echo "$_INDEX" | command grep -q -E '^\?\? '); then
-      _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_UNTRACKED"
-    fi
-    if $(echo "$_INDEX" | command grep -q '^UU '); then
-      _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_UNMERGED"
-    fi
-  else
+  if $(echo "$_INDEX" | command grep -q '^[AMRD]. '); then
+    _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_STAGED"
+  fi
+  if $(echo "$_INDEX" | command grep -q '^.[MTD] '); then
+    _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_UNSTAGED"
+  fi
+  if $(echo "$_INDEX" | command grep -q -E '^\?\? '); then
+    _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_UNTRACKED"
+  fi
+  if $(echo "$_INDEX" | command grep -q '^UU '); then
+    _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_UNMERGED"
+  fi
+
+  # clean if no file changes (ignore the branch tracking line)
+  if ! $(echo "$_INDEX" | command grep -q -v '^## '); then
     _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_CLEAN"
   fi
 
   # check status of local repository
-  _INDEX=$(command git status --porcelain -b 2> /dev/null)
   if $(echo "$_INDEX" | command grep -q '^## .*ahead'); then
     _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_AHEAD"
   fi

--- a/vero.zsh-theme
+++ b/vero.zsh-theme
@@ -1,6 +1,6 @@
 # Vero theme for Zsh
 #
-# Copyright (c) 2017-2021 Jade Michael Thornton
+# Copyright (c) 2017-2026 Jade Michael Thornton
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/vero.zsh-theme
+++ b/vero.zsh-theme
@@ -42,7 +42,6 @@ ZSH_THEME_GIT_PROMPT_UNSTAGED="%{$fg_bold[yellow]%}•%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg_bold[red]%}•%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_UNMERGED="%{$fg_bold[red]%}✕%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_DIVERGED="%{$fg[magenta]%}↕%{$reset_color%}"
-ZSH_THEME_GIT_PROMPT_STASHED="%{$fg_bold[blue]%}⚑%{$reset_color%}"
 
 vero_git_branch () {
   ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
@@ -57,19 +56,19 @@ vero_git_status() {
   local _branch_status="${_lines[1]}"
 
   # check status of files
-  if (( ${#${(M)_lines:#[AMRD]? *}} )); then
+  if (( ${#${(@M)_lines:#[AMRD]? *}} )); then
     _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_STAGED"
     _has_changes=1
   fi
-  if (( ${#${(M)_lines:#?[MTD] *}} )); then
+  if (( ${#${(@M)_lines:#?[MTD] *}} )); then
     _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_UNSTAGED"
     _has_changes=1
   fi
-  if (( ${#${(M)_lines:#\?\? *}} )); then
+  if (( ${#${(@M)_lines:#\?\? *}} )); then
     _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_UNTRACKED"
     _has_changes=1
   fi
-  if (( ${#${(M)_lines:#UU *}} )); then
+  if (( ${#${(@M)_lines:#UU *}} )); then
     _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_UNMERGED"
     _has_changes=1
   fi
@@ -87,10 +86,6 @@ vero_git_status() {
   fi
   if [[ "$_branch_status" == *diverged* ]]; then
     _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_DIVERGED"
-  fi
-
-  if command git rev-parse --verify refs/stash &> /dev/null; then
-    _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_STASHED"
   fi
 
   echo "$_STATUS"

--- a/vero.zsh-theme
+++ b/vero.zsh-theme
@@ -157,22 +157,6 @@ fi
 _USERNAME="$_USERNAME%{$reset_color%}@%m"
 _LIBERTY="$_LIBERTY%{$reset_color%}"
 
-
-get_space () {
-  local STR=$1$2
-  local zero='%([BSUbfksu]|([FB]|){*})'
-  local LENGTH=${#${(S%%)STR//$~zero/}}
-  local SPACES=""
-  (( LENGTH = ${COLUMNS} - $LENGTH - 1))
-
-  for i in {0..$LENGTH}
-    do
-      SPACES="$SPACES "
-    done
-
-  echo $SPACES
-}
-
 vero_precmd () {
   _TIME="%*"
   _ENV_LINE="$(python_prompt_info) $(node_prompt_info) $(vero_git_prompt)"

--- a/vero.zsh-theme
+++ b/vero.zsh-theme
@@ -24,13 +24,9 @@ autoload colors && colors
 
 ZSH_THEME_NODE_PROMPT_PREFIX="⟦node "
 ZSH_THEME_NODE_PROMPT_SUFFIX="⟧"
-ZSH_THEME_NVM_PROMPT_PREFIX="⟦nvm "
-ZSH_THEME_NVM_PROMPT_SUFFIX="⟧"
 
 ZSH_THEME_PYTHON_PROMPT_PREFIX="⟦py "
 ZSH_THEME_PYTHON_PROMPT_SUFFIX="⟧"
-ZSH_THEME_PYENV_PROMPT_PREFIX="⟦py "
-ZSH_THEME_PYENV_PROMPT_SUFFIX="⟧"
 
 ZSH_THEME_GIT_PROMPT_PREFIX="⟦%{$fg_bold[cyan]%}%{$reset_color%}%{$fg_bold[white]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}⟧"
@@ -112,8 +108,8 @@ fi
 function node_prompt_info() {
   command -v node &>/dev/null || return
   local node_ver=${$(node --version)#v}
-  local _prefix="${ZSH_THEME_NODE_PROMPT_PREFIX:-$ZSH_THEME_NVM_PROMPT_PREFIX}"
-  local _suffix="${ZSH_THEME_NODE_PROMPT_SUFFIX:-$ZSH_THEME_NVM_PROMPT_SUFFIX}"
+  local _prefix="${ZSH_THEME_NVM_PROMPT_PREFIX:-$ZSH_THEME_NODE_PROMPT_PREFIX}"
+  local _suffix="${ZSH_THEME_NVM_PROMPT_SUFFIX:-$ZSH_THEME_NODE_PROMPT_SUFFIX}"
   echo "${_prefix}${node_ver}${_suffix}"
 }
 
@@ -131,8 +127,8 @@ function python_prompt_info() {
     return
   fi
   local python_ver="${$($python_cmd --version 2>&1)#Python }"
-  local _prefix="${ZSH_THEME_PYTHON_PROMPT_PREFIX:-$ZSH_THEME_PYENV_PROMPT_PREFIX}"
-  local _suffix="${ZSH_THEME_PYTHON_PROMPT_SUFFIX:-$ZSH_THEME_PYENV_PROMPT_SUFFIX}"
+  local _prefix="${ZSH_THEME_PYENV_PROMPT_PREFIX:-$ZSH_THEME_PYTHON_PROMPT_PREFIX}"
+  local _suffix="${ZSH_THEME_PYENV_PROMPT_SUFFIX:-$ZSH_THEME_PYTHON_PROMPT_SUFFIX}"
   echo "${_prefix}${python_ver}${_suffix}"
 }
 

--- a/vero.zsh-theme
+++ b/vero.zsh-theme
@@ -27,6 +27,8 @@ ZSH_THEME_NODE_PROMPT_SUFFIX="⟧"
 ZSH_THEME_NVM_PROMPT_PREFIX="⟦nvm "
 ZSH_THEME_NVM_PROMPT_SUFFIX="⟧"
 
+ZSH_THEME_PYTHON_PROMPT_PREFIX="⟦py "
+ZSH_THEME_PYTHON_PROMPT_SUFFIX="⟧"
 ZSH_THEME_PYENV_PROMPT_PREFIX="⟦py "
 ZSH_THEME_PYENV_PROMPT_SUFFIX="⟧"
 
@@ -126,10 +128,23 @@ function nvm_prompt_info() {
   node_prompt_info
 }
 
+function python_prompt_info() {
+  local python_cmd
+  if command -v python &>/dev/null; then
+    python_cmd=python
+  elif command -v python3 &>/dev/null; then
+    python_cmd=python3
+  else
+    return
+  fi
+  local python_ver="${$($python_cmd --version 2>&1)#Python }"
+  local _prefix="${ZSH_THEME_PYTHON_PROMPT_PREFIX:-$ZSH_THEME_PYENV_PROMPT_PREFIX}"
+  local _suffix="${ZSH_THEME_PYTHON_PROMPT_SUFFIX:-$ZSH_THEME_PYENV_PROMPT_SUFFIX}"
+  echo "${_prefix}${python_ver}${_suffix}"
+}
+
 function pyenv_prompt_info() {
-  which pyenv &>/dev/null || return
-  local pyenv_prompt="${$(pyenv version)% \(*\)}"
-  echo "${ZSH_THEME_PYENV_PROMPT_PREFIX}${pyenv_prompt}${ZSH_THEME_PYENV_PROMPT_SUFFIX}"
+  python_prompt_info
 }
 
 _PATH="%{$fg_bold[white]%}%~%{$reset_color%} "
@@ -162,7 +177,7 @@ get_space () {
 
 vero_precmd () {
   _TIME="%*"
-  _ENV_LINE="$(pyenv_prompt_info) $(node_prompt_info) $(vero_git_prompt)"
+  _ENV_LINE="$(python_prompt_info) $(node_prompt_info) $(vero_git_prompt)"
   _SSH="$(ssh_connection) "
   _PROMPT="$_TIME$_SSH$_USERNAME:$_PATH$_ENV_LINE"
   print

--- a/vero.zsh-theme
+++ b/vero.zsh-theme
@@ -37,7 +37,6 @@ ZSH_THEME_GIT_PROMPT_STAGED="%{$fg_bold[green]%}•%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_UNSTAGED="%{$fg_bold[yellow]%}•%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg_bold[red]%}•%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_UNMERGED="%{$fg_bold[red]%}✕%{$reset_color%}"
-ZSH_THEME_GIT_PROMPT_DIVERGED="%{$fg[magenta]%}↕%{$reset_color%}"
 
 vero_git_branch () {
   ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
@@ -80,10 +79,6 @@ vero_git_status() {
   if [[ "$_branch_status" == *behind* ]]; then
     _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_BEHIND"
   fi
-  if [[ "$_branch_status" == *diverged* ]]; then
-    _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_DIVERGED"
-  fi
-
   echo "$_STATUS"
 }
 

--- a/vero.zsh-theme
+++ b/vero.zsh-theme
@@ -39,6 +39,7 @@ ZSH_THEME_GIT_PROMPT_UNTRACKED="%{$fg_bold[red]%}•%{$reset_color%}"
 ZSH_THEME_GIT_PROMPT_UNMERGED="%{$fg_bold[red]%}✕%{$reset_color%}"
 
 vero_git_branch () {
+  local ref
   ref=$(command git symbolic-ref HEAD 2> /dev/null) || \
   ref=$(command git rev-parse --short HEAD 2> /dev/null) || return
   echo "${ref#refs/heads/}"

--- a/vero.zsh-theme
+++ b/vero.zsh-theme
@@ -47,40 +47,45 @@ vero_git_branch () {
 }
 
 vero_git_status() {
-  _STATUS=""
-  _INDEX=$(command git status --porcelain -b 2> /dev/null)
+  local _STATUS="" _has_changes=0
+  local _INDEX=$(command git status --porcelain -b 2> /dev/null)
+  local -a _lines=("${(f)_INDEX}")
+  local _branch_status="${_lines[1]}"
 
   # check status of files
-  if $(echo "$_INDEX" | command grep -q '^[AMRD]. '); then
+  if (( ${#${(M)_lines:#[AMRD]? *}} )); then
     _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_STAGED"
+    _has_changes=1
   fi
-  if $(echo "$_INDEX" | command grep -q '^.[MTD] '); then
+  if (( ${#${(M)_lines:#?[MTD] *}} )); then
     _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_UNSTAGED"
+    _has_changes=1
   fi
-  if $(echo "$_INDEX" | command grep -q -E '^\?\? '); then
+  if (( ${#${(M)_lines:#\?\? *}} )); then
     _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_UNTRACKED"
+    _has_changes=1
   fi
-  if $(echo "$_INDEX" | command grep -q '^UU '); then
+  if (( ${#${(M)_lines:#UU *}} )); then
     _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_UNMERGED"
+    _has_changes=1
   fi
 
-  # clean if no file changes (ignore the branch tracking line)
-  if ! $(echo "$_INDEX" | command grep -q -v '^## '); then
+  if (( ! _has_changes )); then
     _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_CLEAN"
   fi
 
-  # check status of local repository
-  if $(echo "$_INDEX" | command grep -q '^## .*ahead'); then
+  # check branch tracking status
+  if [[ "$_branch_status" == *ahead* ]]; then
     _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_AHEAD"
   fi
-  if $(echo "$_INDEX" | command grep -q '^## .*behind'); then
+  if [[ "$_branch_status" == *behind* ]]; then
     _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_BEHIND"
   fi
-  if $(echo "$_INDEX" | command grep -q '^## .*diverged'); then
+  if [[ "$_branch_status" == *diverged* ]]; then
     _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_DIVERGED"
   fi
 
-  if $(command git rev-parse --verify refs/stash &> /dev/null); then
+  if command git rev-parse --verify refs/stash &> /dev/null; then
     _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_STASHED"
   fi
 

--- a/vero.zsh-theme
+++ b/vero.zsh-theme
@@ -22,6 +22,8 @@
 
 autoload colors && colors
 
+ZSH_THEME_NODE_PROMPT_PREFIX="⟦node "
+ZSH_THEME_NODE_PROMPT_SUFFIX="⟧"
 ZSH_THEME_NVM_PROMPT_PREFIX="⟦nvm "
 ZSH_THEME_NVM_PROMPT_SUFFIX="⟧"
 
@@ -112,10 +114,16 @@ function ssh_connection() {
   fi
 }
 
+function node_prompt_info() {
+  command -v node &>/dev/null || return
+  local node_ver=${$(node --version)#v}
+  local _prefix="${ZSH_THEME_NODE_PROMPT_PREFIX:-$ZSH_THEME_NVM_PROMPT_PREFIX}"
+  local _suffix="${ZSH_THEME_NODE_PROMPT_SUFFIX:-$ZSH_THEME_NVM_PROMPT_SUFFIX}"
+  echo "${_prefix}${node_ver}${_suffix}"
+}
+
 function nvm_prompt_info() {
-  which nvm &>/dev/null || return
-  local nvm_prompt=${$(nvm current)#v}
-  echo "${ZSH_THEME_NVM_PROMPT_PREFIX}${nvm_prompt}${ZSH_THEME_NVM_PROMPT_SUFFIX}"
+  node_prompt_info
 }
 
 function pyenv_prompt_info() {
@@ -154,7 +162,7 @@ get_space () {
 
 vero_precmd () {
   _TIME="%*"
-  _ENV_LINE="$(pyenv_prompt_info) $(nvm_prompt_info) $(vero_git_prompt)"
+  _ENV_LINE="$(pyenv_prompt_info) $(node_prompt_info) $(vero_git_prompt)"
   _SSH="$(ssh_connection) "
   _PROMPT="$_TIME$_SSH$_USERNAME:$_PATH$_ENV_LINE"
   print

--- a/vero.zsh-theme
+++ b/vero.zsh-theme
@@ -110,11 +110,9 @@ vero_git_prompt () {
   echo "$_result"
 }
 
-function ssh_connection() {
-  if [[ -n $SSH_CONNECTION ]]; then
-    echo "%{$fg_bold[red]%} (ssh)"
-  fi
-}
+if [[ -n $SSH_CONNECTION ]]; then
+  _VERO_SSH="%{$fg_bold[red]%} (ssh)"
+fi
 
 function node_prompt_info() {
   command -v node &>/dev/null || return
@@ -178,8 +176,7 @@ get_space () {
 vero_precmd () {
   _TIME="%*"
   _ENV_LINE="$(python_prompt_info) $(node_prompt_info) $(vero_git_prompt)"
-  _SSH="$(ssh_connection) "
-  _PROMPT="$_TIME$_SSH$_USERNAME:$_PATH$_ENV_LINE"
+  _PROMPT="$_TIME$_VERO_SSH $_USERNAME:$_PATH$_ENV_LINE"
   print
   print -rP "$_PROMPT"
 }

--- a/vero.zsh-theme
+++ b/vero.zsh-theme
@@ -89,7 +89,7 @@ vero_git_status() {
     _STATUS="$_STATUS$ZSH_THEME_GIT_PROMPT_STASHED"
   fi
 
-  echo $_STATUS
+  echo "$_STATUS"
 }
 
 vero_git_prompt () {
@@ -103,7 +103,7 @@ vero_git_prompt () {
     fi
     _result="$_result$ZSH_THEME_GIT_PROMPT_SUFFIX"
   fi
-  echo $_result
+  echo "$_result"
 }
 
 function ssh_connection() {


### PR DESCRIPTION
## Summary

- Define missing git prompt theme variable (`UNMERGED`) that was used but never defined
- Remove non-functional stash and diverged detection (variables were never defined and diverged check could never match porcelain output)
- Consolidate two `git status` calls into one and replace grep subprocesses with native zsh pattern matching (eliminates ~7 subprocess forks per prompt)
- Replace nvm/pyenv-specific version checks with `node --version` and `python --version`, which work with any version manager (mise, fnm, volta, uv, etc.)
- Compute SSH status once at theme load time instead of every prompt
- Remove dead `get_space()` function
- Add backfilled changelog, update copyright and README

## Backward compatibility

- `nvm_prompt_info` and `pyenv_prompt_info` functions still exist as wrappers, so user configs calling them directly continue to work
- `ZSH_THEME_NVM_PROMPT_PREFIX/SUFFIX` and `ZSH_THEME_PYENV_PROMPT_PREFIX/SUFFIX` are checked first in the version display functions; if a user has customized them, their values are used. If not set, the new `ZSH_THEME_NODE_PROMPT_PREFIX/SUFFIX` and `ZSH_THEME_PYTHON_PROMPT_PREFIX/SUFFIX` defaults are used.

## Test plan

- [ ] Source theme in a fresh zsh session, verify prompt renders
- [ ] Verify git indicators in a repo with staged, unstaged, and untracked changes
- [ ] Verify node version appears (with any version manager)
- [ ] Verify python version appears
- [ ] Verify SSH indicator with `SSH_CONNECTION=test source vero.zsh-theme`
- [ ] Verify `nvm_prompt_info` and `pyenv_prompt_info` still work when called directly
- [ ] Verify setting `ZSH_THEME_NVM_PROMPT_PREFIX` before sourcing overrides the default